### PR TITLE
Resolved issue when writing to HOSTS

### DIFF
--- a/lib/Common/HOSTS/Kabatra.Common.HOSTS.Write-HostsFile.ps1
+++ b/lib/Common/HOSTS/Kabatra.Common.HOSTS.Write-HostsFile.ps1
@@ -30,7 +30,7 @@ function Kabatra.Common.HOSTS.Append-HostsFileContent
 
     if($HostsFileContent -notcontains $ContentToAppend)
     {
-        Add-Content -Path $hostsFilePath -Value $ContentToAppend
+        $ContentToAppend | Out-File -FilePath $hostsFilePath -Append -Force
     }
 }
 
@@ -46,7 +46,7 @@ function Kabatra.Common.HOSTS.Remove-HostsFileContent
     if($HostsFileContent -contains $ContentToRemove)
     {
         # Clear the HOSTS file
-        Clear-Content -Path $hostsFilePath
+        "" | Out-File -FilePath $hostsFilePath -Force
 
         $filteredContent = [System.Collections.ArrayList]@()
         foreach($line in $HostsFileContent)
@@ -59,10 +59,10 @@ function Kabatra.Common.HOSTS.Remove-HostsFileContent
             $filteredContent.Add($line) > $null;
         }
 
-        Add-Content -Path $hostsFilePath -Value $filteredContent -ErrorAction Continue -ErrorVariable setOriginalContentOnError        
-        if($setOriginalContentOnError -or $filteredContent.Count -eq 0)
+        $filteredContent | Out-File -FilePath $hostsFilePath -Force -ErrorAction Continue -ErrorVariable setOriginalContentOnError        
+        if($setOriginalContentOnError)
         {
-            Set-Content -Path $hostsFilePath -Value $HostsFileContent
+            $HostsFileContent | Out-File -FilePath $hostsFilePath -Force
             throw "There was an error, reverting any changes to HOSTS file."
         }
     }


### PR DESCRIPTION
Add-Content, Clear-Content, and Set-Content all needed to establish a file lock in order to write to the file. This caused errors to be thrown when enabling and disabling sites which often left the system is a partial state. Either some of the sites would be enabled or disabled.

I changed the code to use Out-File as it does not require a lock on the file. In addition I removed the last error check for an empty HOSTS file, because in theory that could be a valid case.

Closes #2 